### PR TITLE
Add GitHub action worflow for phpunit

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,55 @@
+# Contributing
+
+Contributions are **welcome** and will be fully **credited**.
+
+Please read and understand the contribution guide before creating an issue or pull request.
+
+## Etiquette
+
+This project is open source, and as such, the maintainers give their free time to build and maintain the source code
+held within. They make the code freely available in the hope that it will be of use to other developers. It would be
+extremely unfair for them to suffer abuse or anger for their hard work.
+
+Please be considerate towards maintainers when raising issues or presenting pull requests. Let's show the
+world that developers are civilized and selfless people.
+
+It's the duty of the maintainer to ensure that all submissions to the project are of sufficient
+quality to benefit the project. Many developers have different skillsets, strengths, and weaknesses. Respect the maintainer's decision, and do not be upset or abusive if your submission is not used.
+
+## Viability
+
+When requesting or submitting new features, first consider whether it might be useful to others. Open
+source projects are used by many developers, who may have entirely different needs to your own. Think about
+whether or not your feature is likely to be used by other users of the project.
+
+## Procedure
+
+Before filing an issue:
+
+- Attempt to replicate the problem, to ensure that it wasn't a coincidental incident.
+- Check to make sure your feature suggestion isn't already present within the project.
+- Check the pull requests tab to ensure that the bug doesn't have a fix in progress.
+- Check the pull requests tab to ensure that the feature isn't already in progress.
+
+Before submitting a pull request:
+
+- Check the codebase to ensure that your feature doesn't already exist.
+- Check the pull requests to ensure that another person hasn't already submitted the feature or fix.
+
+## Requirements
+
+If the project maintainer has any additional requirements, you will find them listed here.
+
+- **[PSR-2 Coding Standard](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-2-coding-style-guide.md)** - The easiest way to apply the conventions is to install [PHP Code Sniffer](https://pear.php.net/package/PHP_CodeSniffer).
+
+- **Add tests!** - Your patch won't be accepted if it doesn't have tests.
+
+- **Document any change in behaviour** - Make sure the `README.md` and any other relevant documentation are kept up-to-date.
+
+- **Consider our release cycle** - We try to follow [SemVer v2.0.0](https://semver.org/). Randomly breaking public APIs is not an option.
+
+- **One pull request per feature** - If you want to do more than one thing, send multiple pull requests.
+
+- **Send coherent history** - Make sure each individual commit in your pull request is meaningful. If you had to make multiple intermediate commits while developing, please [squash them](https://www.git-scm.com/book/en/v2/Git-Tools-Rewriting-History#Changing-Multiple-Commit-Messages) before submitting.
+
+**Happy coding**!

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,0 +1,3 @@
+# Security Policy
+
+If you discover any security related issues, please email info@dogado.dev instead of using the issue tracker.

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -1,0 +1,47 @@
+name: phpunit
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: true
+      matrix:
+        os:
+          - ubuntu-latest
+        php:
+          - 7.3
+          - 7.4
+          - 8.0
+        dependency-version: [prefer-lowest, prefer-stable]
+
+    name: php${{ matrix.php }} - ${{ matrix.dependency-version }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          coverage: xdebug
+
+      - name: Setup Problem Matches
+        run: |
+          echo "::add-matcher::${{ runner.tool_cache }}/php.json"
+          echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
+
+      - name: Install dependencies
+        run: composer update --${{ matrix.dependency-version }} --prefer-dist --no-interaction
+
+      - name: Execute tests
+        run: vendor/bin/phpunit -v --coverage-text --coverage-clover build/logs/clover.xml
+
+      - name: Upload coverage results to Coveralls
+        env:
+          COVERALLS_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          composer global require php-coveralls/php-coveralls
+          php-coveralls --coverage_clover=build/logs/clover.xml -v

--- a/README.md
+++ b/README.md
@@ -1,6 +1,13 @@
 dogado Cookie Manager for Laravel
 ===============
 
+[![phpunit](https://github.com/dogado-group/laravel-cookie-manager/actions/workflows/phpunit.yml/badge.svg)](https://github.com/dogado-group/laravel-cookie-manager/actions/workflows/phpunit.yml)
+[![Coverage Status](https://coveralls.io/repos/github/dogado-group/laravel-cookie-manager/badge.svg?branch=main)](https://coveralls.io/github/dogado-group/laravel-cookie-manager?branch=main)
+[![Total Downloads](https://poser.pugx.org/dogado/laravel-cookie-manager/downloads)](https://packagist.org/packages/dogado/laravel-cookie-manager)
+[![Latest Stable Version](https://poser.pugx.org/dogado/laravel-cookie-manager/v/stable)](https://packagist.org/packages/dogado/laravel-cookie-manager)
+[![Latest Unstable Version](https://poser.pugx.org/dogado/laravel-cookie-manager/v/unstable.png)](https://packagist.org/packages/dogado/laravel-cookie-manager)
+[![License](https://poser.pugx.org/dogado/laravel-cookie-manager/license)](https://packagist.org/packages/dogado/laravel-cookie-manager)
+
 <!-- TOC -->
 
 1. [Introduction](#introduction)

--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ dogado Cookie Manager for Laravel
 A client library package for Laravel based projects, maintained by the [dogado GmbH](https://dogado.de).
 
 ## Requirements
-* php 7.3
-* `symfony/http-foundation` version `^4.2` or `^5.0`
+* php `^7.3` or `^8.0`
+* `symfony/http-foundation` version `^4.4` or `^5.0`
 
 ## Steps to configure
 

--- a/composer.json
+++ b/composer.json
@@ -10,9 +10,8 @@
     "symfony/http-foundation": "^4.2|^5.0"
   },
   "require-dev": {
-    "mockery/mockery": "^1.4",
     "fakerphp/faker": "^1.14",
-    "phpunit/phpunit": "^9.3"
+    "phpunit/phpunit": "^9.5"
   },
   "autoload": {
     "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
   "require": {
     "php": "^7.3|^8.0",
     "cbschuld/browser.php": "^1.9",
-    "symfony/http-foundation": "^4.2|^5.0"
+    "symfony/http-foundation": "^4.4|^5.0"
   },
   "require-dev": {
     "fakerphp/faker": "^1.14",


### PR DESCRIPTION
This PR add's the GitHub action workflow for phpunit and drops support for Symfony `<4.4`. The constraint change had to be done due to failing tests in lower version.