### PR TITLE
php 8.1 compatibility

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -14,6 +14,7 @@ jobs:
           - 7.3
           - 7.4
           - 8.0
+          - 8.1
         dependency-version: [prefer-lowest, prefer-stable]
 
     name: php${{ matrix.php }} - ${{ matrix.dependency-version }}

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
   "require": {
     "php": "^7.3|^8.0",
     "cbschuld/browser.php": "^1.9",
-    "symfony/http-foundation": "^4.4|^5.0"
+    "symfony/http-foundation": "^4.4.30|^5.3.7"
   },
   "require-dev": {
     "fakerphp/faker": "^1.14",


### PR DESCRIPTION
This PR ensures the compatibility of this package with php8.1. The `symfony/http-foundation` dependency had to be adjusted, due to the following required change: https://github.com/symfony/symfony/commit/3eca446b21607ea1c7a865ece2dd8254c33679cc
```
Fatal error: During inheritance of IteratorAggregate: Uncaught Return type of Symfony\Component\HttpFoundation\ParameterBag::getIterator() should either be compatible with IteratorAggregate::getIterator(): Traversable, or the #[ReturnTypeWillChange] attribute should be used to temporarily suppress the notice
```